### PR TITLE
Add -L to curl so it follows redirects

### DIFF
--- a/resources/build
+++ b/resources/build
@@ -27,7 +27,7 @@ export KERNELVER=$(uname -r  | cut -d '-' -f 1)
 export KERNELDIR=/linux-$KERNELVER
 
 cd /
-curl -o linux-${KERNELVER}.tar.gz https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNELVER}.tar.gz
+curl -L -o linux-${KERNELVER}.tar.gz https://www.kernel.org/pub/linux/kernel/v4.x/linux-${KERNELVER}.tar.gz
 tar zxf linux-${KERNELVER}.tar.gz
 cd linux-${KERNELVER}
 zcat /proc/1/root/proc/config.gz > .config


### PR DESCRIPTION
It seems that the URL to the kernel files now gets redirected to a
mirror, so we need curl to follow redirects